### PR TITLE
Switch to the Node 12 experimental module system

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-/index.js
+/umd.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.nyc_output/
 /coverage/
-/index.js
 /node_modules/
+/umd.js

--- a/index.mjs
+++ b/index.mjs
@@ -10,6 +10,13 @@
 //. ```console
 //. $ npm install --save monastic
 //. ```
+//.
+//. On Node 12 and up, you can use `import {State} from 'monastic'`.
+//. Older versions of Node require the use of
+//. [`esm`](https://github.com/standard-things/esm).
+//.
+//. Alternatively, a universal module can be obtained
+//. through `require('monastic/umd')`.
 
 import Z from 'sanctuary-type-classes';
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "monastic",
   "version": "1.0.1",
   "description": "A functional approach to stateful computations",
-  "main": "index",
+  "type": "commonjs",
+  "main": "index.mjs",
   "module": "index.mjs",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
@@ -10,7 +11,7 @@
     "doctest": "sanctuary-doctest",
     "licensetest": "license-checker --production --onlyAllow 'MIT'",
     "lint": "sanctuary-lint",
-    "prepublishOnly": "rollup -c rollup.config.mjs",
+    "prepublishOnly": "rollup -c rollup.config.js",
     "release": "sanctuary-release",
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
@@ -29,11 +30,11 @@
     "fantasy-land"
   ],
   "files": [
-    "/index.js",
     "/index.mjs",
     "/LICENSE",
     "/package.json",
-    "README.md"
+    "/README.md",
+    "/umd.js"
   ],
   "devDependencies": {
     "coveralls": "^3.0.2",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -6,7 +6,7 @@ export default {
   output: {
     format: 'umd',
     name: 'Monastic',
-    file: 'index.js',
+    file: 'umd.js',
     interop: false,
     globals: {
       'sanctuary-type-classes': 'sanctuaryTypeClasses'


### PR DESCRIPTION
# Motivation

Node 12 has introduced breaking changes to the way that the experimental module system works. Users of experimental modules will expect packages to follow this new system going forward.

# Changes

- Package entry point change from `index` to `index.mjs`: Node 12 no longer switches transparently between the most appropriate `index` file. Every package must provide an explicit path to its entry-point.
- Build output renamed to `umd.js`: User have to deep-require this file now, as the package entry point is a `.mjs` file. I think using a specific name like this is clearer than using `index.js`.
- ["Package type"](https://nodejs.org/api/esm.html#esm_code_package_json_code_code_type_code_field) set to `commonjs`: This is a way for Node 12 to understand what the type is of files that don't express the type in their extension. We use commonjs so that our `.js` files are treated as such, so that we keep backwards compatibility on those files with older versions of Node.
- Rollup config file extension changed: Node 12 forbids `require('*.mjs')` calls. Since this is how, deep down, the file was being loaded by Rollup, we get an error in Node 12.

# Tests

The tests in this module run through Mocha and nyc. Since Mocha and/or nyc use `require` to load the files, and Node 12 forbids `require('*.mjs')` now, the tests don't run in Node 12. I left this problem for another time. In Fluture, I switched to an approach where I run the tests natively [using c8 and oletus](https://github.com/fluture-js/Fluture/pull/368).