### PR TITLE
Switch to ESM-first for package distribution

### DIFF
--- a/.config
+++ b/.config
@@ -1,6 +1,6 @@
 author-name = WEAREREASONABLEPEOPLE B.V.
 repo-owner = wearereasonablepeople
 repo-name = monastic
-source-files = index.mjs
+source-files = index.js
 opening-delimiter = ```js
 module-type = esm

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,1 +1,1 @@
-/index.js
+/index.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 /.nyc_output/
 /coverage/
-/index.js
 /node_modules/
+/index.cjs

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-/.nyc_output/
 /coverage/
 /node_modules/
 /index.cjs

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,6 @@
 language: node_js
 
 node_js:
-  - 8
-  - 9
-  - 10
-  - 11
+  - 12
 
 after_success: npm run coverage

--- a/index.js
+++ b/index.js
@@ -10,6 +10,13 @@
 //. ```console
 //. $ npm install --save monastic
 //. ```
+//.
+//. On Node 12 and up, you can use `import {State} from 'monastic'`.
+//. Older versions of Node require the use of
+//. [`esm`](https://github.com/standard-things/esm).
+//.
+//. Alternatively, a universal module can be obtained
+//. through `require('monastic/index.cjs')`.
 
 import Z from 'sanctuary-type-classes';
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
   "module": "index.js",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
-    "deps": "depcheck --ignores='sanctuary-style'",
     "doctest": "sanctuary-doctest",
     "licensetest": "license-checker --production --onlyAllow 'MIT'",
     "lint": "sanctuary-lint",
@@ -37,12 +36,13 @@
     "/index.cjs"
   ],
   "devDependencies": {
+    "c8": "^5.0.4",
     "coveralls": "^3.0.2",
     "depcheck": "^0.6.9",
-    "esm": "^3.0.69",
     "fantasy-laws": "^1.1.0",
     "jsverify": "^0.8.3",
     "license-checker": "^20.1.0",
+    "oletus": "^2.0.0",
     "rollup": "^0.63.4",
     "sanctuary-maybe": "^1.0.0",
     "sanctuary-scripts": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -2,15 +2,16 @@
   "name": "monastic",
   "version": "1.0.1",
   "description": "A functional approach to stateful computations",
-  "main": "index",
-  "module": "index.mjs",
+  "type": "module",
+  "main": "index.js",
+  "module": "index.js",
   "scripts": {
     "coverage": "nyc report --reporter=text-lcov | coveralls",
     "deps": "depcheck --ignores='sanctuary-style'",
     "doctest": "sanctuary-doctest",
     "licensetest": "license-checker --production --onlyAllow 'MIT'",
     "lint": "sanctuary-lint",
-    "prepublishOnly": "rollup -c rollup.config.mjs",
+    "prepublishOnly": "rollup -c rollup.config.js",
     "release": "sanctuary-release",
     "test": "npm run lint && sanctuary-test && npm run doctest"
   },
@@ -30,10 +31,10 @@
   ],
   "files": [
     "/index.js",
-    "/index.mjs",
     "/LICENSE",
     "/package.json",
-    "README.md"
+    "/README.md",
+    "/index.cjs"
   ],
   "devDependencies": {
     "coveralls": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -38,16 +38,16 @@
   "devDependencies": {
     "c8": "^5.0.4",
     "coveralls": "^3.0.2",
-    "depcheck": "^0.6.9",
+    "depcheck": "^0.8.3",
     "fantasy-laws": "^1.1.0",
     "jsverify": "^0.8.3",
-    "license-checker": "^20.1.0",
+    "license-checker": "^25.0.1",
     "oletus": "^2.0.0",
-    "rollup": "^0.63.4",
+    "rollup": "^1.25.2",
     "sanctuary-maybe": "^1.0.0",
     "sanctuary-scripts": "^3.2.0"
   },
   "dependencies": {
-    "sanctuary-type-classes": "^9.0.0"
+    "sanctuary-type-classes": "^11.0.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,12 +1,12 @@
 import pkg from './package.json';
 
 export default {
-  input: 'index.mjs',
+  input: 'index.js',
   external: Object.keys (pkg.dependencies),
   output: {
     format: 'umd',
     name: 'Monastic',
-    file: 'index.js',
+    file: 'index.cjs',
     interop: false,
     globals: {
       'sanctuary-type-classes': 'sanctuaryTypeClasses'

--- a/scripts/test
+++ b/scripts/test
@@ -1,8 +1,18 @@
 #!/usr/bin/env bash
-
 set -euf -o pipefail
 
 npm run licensetest
-npm run deps
 
-sanctuary-test "$@"
+# shellcheck source=../node_modules/sanctuary-scripts/functions
+source "${BASH_SOURCE%/*}/../node_modules/sanctuary-scripts/functions"
+
+branches=$(get min-branch-coverage)
+
+set +f
+c8 --check-coverage \
+   --branches "$branches" \
+   --reporter text \
+   --reporter html \
+   node --experimental-modules \
+        --no-warnings \
+        -- ./node_modules/.bin/oletus test/*.test.js

--- a/test/compliance.test.js
+++ b/test/compliance.test.js
@@ -1,35 +1,23 @@
-import {
-  Functor,
-  Apply,
-  Applicative,
-  Chain,
-  ChainRec,
-  Monad
-} from 'fantasy-laws';
-
-import {
-  letrec,
-  constant as _k,
-  nat
-} from 'jsverify';
-
 import Z from 'sanctuary-type-classes';
 import Maybe from 'sanctuary-maybe';
+import jsc from 'jsverify';
+import FL from 'fantasy-laws';
+import test from 'oletus';
 
 import {
   primitive,
   stateEquals
-} from './utils';
+} from './utils.js';
 
 import {
   State,
   StateT,
   evalState,
   compose as B
-} from '..';
+} from '../index.js';
 
 var StateMaybe = StateT (Maybe);
-var eq = stateEquals (nat);
+var eq = stateEquals (jsc.nat);
 
 function _of(type) {
   return function(value) {
@@ -52,7 +40,7 @@ function Arb(type) {
 var {
   anyState,
   anyStateMaybe
-} = letrec (function(tie) {
+} = jsc.letrec (function(tie) {
   return {
     anyState: Arb (State) (
       tie ('any'), tie ('anyState')
@@ -68,127 +56,96 @@ function low3(x) { return x < 3; }
 function mul3(x) { return x * 3; }
 function sub3(x) { return x - 3; }
 
-suite ('Compliance to Fantasy Land', function() {
-  suite ('State', function() {
-    suite ('Functor', function() {
-      test ('identity', Functor (eq).identity (anyState));
-      test ('composition', Functor (eq).composition (
-        Arb (State) (nat),
-        _k (sub3),
-        _k (mul3)
-      ));
-    });
+test ('Functor identity', FL.Functor (eq).identity (anyState));
+test ('Functor composition', FL.Functor (eq).composition (
+  Arb (State) (jsc.nat),
+  jsc.constant (sub3),
+  jsc.constant (mul3)
+));
 
-    suite ('Apply', function() {
-      test ('composition', Apply (eq).composition (
-        Arb (State) (_k (sub3)),
-        Arb (State) (_k (mul3)),
-        Arb (State) (nat)
-      ));
-    });
+test ('Apply composition', FL.Apply (eq).composition (
+  Arb (State) (jsc.constant (sub3)),
+  Arb (State) (jsc.constant (mul3)),
+  Arb (State) (jsc.nat)
+));
 
-    suite ('Applicative', function() {
-      test ('identity', Applicative (eq, State).identity (Arb (State) (anyState)));
-      test ('homomorphism', Applicative (eq, State).homomorphism (
-        _k (sub3),
-        nat
-      ));
-      test ('interchange', Applicative (eq, State).interchange (
-        Arb (State) (_k (sub3)),
-        nat
-      ));
-    });
+test ('Applicative identity', FL.Applicative (eq, State).identity (Arb (State) (anyState)));
+test ('Applicative homomorphism', FL.Applicative (eq, State).homomorphism (
+  jsc.constant (sub3),
+  jsc.nat
+));
+test ('Applicative interchange', FL.Applicative (eq, State).interchange (
+  Arb (State) (jsc.constant (sub3)),
+  jsc.nat
+));
 
-    suite ('Chain', function() {
-      test ('associativity', Chain (eq).associativity (
-        Arb (State) (nat),
-        _k (B (_of (State)) (sub3)),
-        _k (B (_of (State)) (mul3))
-      ));
-    });
+test ('Chain associativity', FL.Chain (eq).associativity (
+  Arb (State) (jsc.nat),
+  jsc.constant (B (_of (State)) (sub3)),
+  jsc.constant (B (_of (State)) (mul3))
+));
 
-    suite ('Monad', function() {
-      test ('leftIdentity', Monad (eq, State).leftIdentity (
-        _k (B (_of (State)) (mul3)),
-        nat
-      ));
-      test ('rightIdentity', Monad (eq, State).rightIdentity (
-        Arb (State) (anyState)
-      ));
-    });
+test ('Monad leftIdentity', FL.Monad (eq, State).leftIdentity (
+  jsc.constant (B (_of (State)) (mul3)),
+  jsc.nat
+));
+test ('Monad rightIdentity', FL.Monad (eq, State).rightIdentity (
+  Arb (State) (anyState)
+));
 
-    suite ('ChainRec', function() {
-      test ('equivalence', ChainRec (eq, State).equivalence (
-        _k (low3),
-        _k (B (_of (State)) (Math.sqrt)),
-        _k (_of (State)),
-        nat.smap (
-          function(x) { return Math.min (x, 100); },
-          function(x) { return x; }
-        )
-      ));
-    });
-  });
+test ('ChainRec equivalence', FL.ChainRec (eq, State).equivalence (
+  jsc.constant (low3),
+  jsc.constant (B (_of (State)) (Math.sqrt)),
+  jsc.constant (_of (State)),
+  jsc.nat.smap (
+    function(x) { return Math.min (x, 100); },
+    function(x) { return x; }
+  )
+));
 
-  suite ('StateT', function() {
-    suite ('Functor', function() {
-      test ('identity', Functor (eq).identity (anyStateMaybe));
-      test ('composition', Functor (eq).composition (
-        Arb (StateMaybe) (nat),
-        _k (sub3),
-        _k (sub3)
-      ));
-    });
+test ('StateT Functor identity', FL.Functor (eq).identity (anyStateMaybe));
+test ('StateT Functor composition', FL.Functor (eq).composition (
+  Arb (StateMaybe) (jsc.nat),
+  jsc.constant (sub3),
+  jsc.constant (sub3)
+));
 
-    suite ('Apply', function() {
-      test ('composition', Apply (eq).composition (
-        Arb (StateMaybe) (_k (mul3)),
-        Arb (StateMaybe) (_k (sub3)),
-        Arb (StateMaybe) (nat)
-      ));
-    });
+test ('StateT Apply composition', FL.Apply (eq).composition (
+  Arb (StateMaybe) (jsc.constant (mul3)),
+  Arb (StateMaybe) (jsc.constant (sub3)),
+  Arb (StateMaybe) (jsc.nat)
+));
 
-    suite ('Applicative', function() {
-      test ('identity', Applicative (eq, StateMaybe).identity (Arb (StateMaybe) (anyStateMaybe)));
-      test ('homomorphism', Applicative (eq, StateMaybe).homomorphism (
-        _k (mul3),
-        nat
-      ));
-      test ('interchange', Applicative (eq, StateMaybe).interchange (
-        Arb (StateMaybe) (_k (sub3)),
-        nat
-      ));
-    });
+test ('StateT Applicative identity', FL.Applicative (eq, StateMaybe).identity (Arb (StateMaybe) (anyStateMaybe)));
+test ('StateT Applicative homomorphism', FL.Applicative (eq, StateMaybe).homomorphism (
+  jsc.constant (mul3),
+  jsc.nat
+));
+test ('interchange', FL.Applicative (eq, StateMaybe).interchange (
+  Arb (StateMaybe) (jsc.constant (sub3)),
+  jsc.nat
+));
 
-    suite ('Chain', function() {
-      test ('associativity', Chain (eq).associativity (
-        Arb (StateMaybe) (anyStateMaybe),
-        _k (B (_of (StateMaybe)) (sub3)),
-        _k (B (_of (StateMaybe)) (mul3))
-      ));
-    });
+test ('StateT Chain associativity', FL.Chain (eq).associativity (
+  Arb (StateMaybe) (anyStateMaybe),
+  jsc.constant (B (_of (StateMaybe)) (sub3)),
+  jsc.constant (B (_of (StateMaybe)) (mul3))
+));
 
-    suite ('Monad', function() {
-      test ('leftIdentity', Monad (eq, StateMaybe).leftIdentity (
-        _k (B (_of (StateMaybe)) (sub3)),
-        nat
-      ));
-      test ('rightIdentity', Monad (eq, StateMaybe).rightIdentity (
-        Arb (StateMaybe) (anyStateMaybe)
-      ));
-    });
+test ('StateT Monad leftIdentity', FL.Monad (eq, StateMaybe).leftIdentity (
+  jsc.constant (B (_of (StateMaybe)) (sub3)),
+  jsc.nat
+));
+test ('StateT Monad rightIdentity', FL.Monad (eq, StateMaybe).rightIdentity (
+  Arb (StateMaybe) (anyStateMaybe)
+));
 
-    suite ('ChainRec', function() {
-      test ('equivalence', ChainRec (eq, StateMaybe).equivalence (
-        _k (low3),
-        _k (B (_of (StateMaybe)) (Math.sqrt)),
-        _k (_of (StateMaybe)),
-        nat.smap (
-          function(x) { return Math.min (x, 100); },
-          function(x) { return x; }
-        )
-      ));
-    });
-
-  });
-});
+test ('StateT ChainRec equivalence', FL.ChainRec (eq, StateMaybe).equivalence (
+  jsc.constant (low3),
+  jsc.constant (B (_of (StateMaybe)) (Math.sqrt)),
+  jsc.constant (_of (StateMaybe)),
+  jsc.nat.smap (
+    function(x) { return Math.min (x, 100); },
+    function(x) { return x; }
+  )
+));

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -1,31 +1,27 @@
-import {
-  fun,
-  constant as _k,
-  nat
-} from 'jsverify';
+import jsc from 'jsverify';
+import test from 'oletus';
 
 import {
   property as _prop,
   truthy
-} from './utils';
+} from './utils.js';
 
 var property = _prop (test);
 
-import {compose, constant} from '..';
+import {compose, constant} from '../index.js';
 
-suite ('Helpers', function() {
-  property (
-    'compose (f) (g) (x) === f (g (x))',
-    _k (Math.sqrt), fun (nat), nat,
-    function(f, g, x) {
-      return compose (f) (g) (x) === f (g (x));
-    }
-  );
-  property (
-    'constant (x) () === x',
-    truthy,
-    function(x) {
-      return constant (x) () === x;
-    }
-  );
-});
+property (
+  'compose (f) (g) (x) === f (g (x))',
+  jsc.constant (Math.sqrt), jsc.fun (jsc.nat), jsc.nat,
+  function(f, g, x) {
+    return compose (f) (g) (x) === f (g (x));
+  }
+);
+
+property (
+  'constant (x) () === x',
+  truthy,
+  function(x) {
+    return constant (x) () === x;
+  }
+);

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,3 +1,0 @@
---bail
---ui tdd
---require esm

--- a/test/state.test.js
+++ b/test/state.test.js
@@ -1,13 +1,14 @@
 import Z from 'sanctuary-type-classes';
 import {deepStrictEqual as eq} from 'assert';
-import {constant as _k, fun, nat} from 'jsverify';
+import jsc from 'jsverify';
+import test from 'oletus';
 
 import {
   property as _property,
   stateEquals,
   identity,
   primitive
-} from './utils';
+} from './utils.js';
 
 import {
   put,
@@ -18,90 +19,85 @@ import {
   State,
   run,
   compose
-} from '..';
+} from '../index.js';
 
 var property = _property (test);
 
-suite ('State', function() {
-  test ('metadata', function() {
-    eq (typeof State, 'function');
-    eq (State.length, 1);
-  });
-  test ('constructor', function() {
-    eq (State (42), new State (42));
-  });
-  suite ('.put', function() {
-    test ('returns a state', function() {
-      eq (put (42) instanceof State, true);
-      eq (put.length, 1);
-    });
-    test ('internal state is set to the given value', function() {
-      eq (execState (0) (put (42)), 42);
-      eq (
-        execState () (Z.chain (function() { return put (42); }, put (21))),
-        42
-      );
-    });
-  });
-  suite ('.modify', function() {
-    test ('returns a state', function() {
-      eq (modify (Function.prototype) instanceof State, true);
-      eq (modify.length, 1);
-    });
-    test ('internal value is set to null', function() {
-      eq (evalState () (modify (Function.prototype)), null);
-      eq (
-        evalState () (Z.chain (
-          function() { return modify (Function.prototype); },
-          Z.of (State, 42)
-        )),
-        null
-      );
-    });
-    property ('put (a).chain (_ => modify (identity)) === put (a)', primitive, function(x) {
-        return stateEquals (primitive) (
-          Z.chain (function() { return modify (identity); }, put (x)),
-          put (x)
-        );
-    });
-    property (
-    'put (a).chain (_ => modify (compose (f) (g))) === put (a).chain (_ => modify (f)).chain (_ => modify (g))'
-    , _k (Math.sqrt), fun (nat), nat, function(f, g, x) {
-      return stateEquals (nat) (
-        Z.chain (function() { return modify (compose (f) (g)); }, put (x)),
-        Z.chain (
-          function() { return modify (f); },
-          Z.chain (function() { return modify (g); }, put (x))
-        )
-      );
-    });
-  });
-  suite ('.get', function() {
-    test ('is a state', function() {
-      eq (get instanceof State, true);
-    });
-    test ('sets the internal value to its state', function() {
-      eq (evalState (42) (get), 42);
-      eq (
-        evalState () (
-          Z.chain (function() { return get; }, put (42))
-        ),
-        42
-      );
-    });
-  });
-  suite ('.run', function() {
-    test ('returns internal state an value', function() {
-      eq (run (42) (get), {state: 42, value: 42});
-    });
-  });
-  suite ('.fantasy-land/chainRec', function() {
-    test ('should be stack-safe', function() {
-      eq (evalState () (
-        Z.chainRec (State, function(next, done, v) {
-          return Z.of (State, v < 10000 ? next (v + 1) : done (v));
-        }, 1)
-      ), 10000);
-    });
-  });
+test ('metadata', function() {
+  eq (typeof State, 'function');
+  eq (State.length, 1);
+});
+test ('constructor', function() {
+  eq (State (42), new State (42));
+});
+
+test ('.put returns a state', function() {
+  eq (put (42) instanceof State, true);
+  eq (put.length, 1);
+});
+test ('.put sets the internal state to the given value', function() {
+  eq (execState (0) (put (42)), 42);
+  eq (
+    execState () (Z.chain (function() { return put (42); }, put (21))),
+    42
+  );
+});
+
+test ('.modify returns a state', function() {
+  eq (modify (Function.prototype) instanceof State, true);
+  eq (modify.length, 1);
+});
+test ('.modify sets the internal value to null', function() {
+  eq (evalState () (modify (Function.prototype)), null);
+  eq (
+    evalState () (Z.chain (
+      function() { return modify (Function.prototype); },
+      Z.of (State, 42)
+    )),
+    null
+  );
+});
+
+property ('put (a).chain (_ => modify (identity)) === put (a)', primitive, function(x) {
+    return stateEquals (primitive) (
+      Z.chain (function() { return modify (identity); }, put (x)),
+      put (x)
+    );
+});
+
+property (
+'put (a).chain (_ => modify (compose (f) (g))) === put (a).chain (_ => modify (f)).chain (_ => modify (g))'
+, jsc.constant (Math.sqrt), jsc.fun (jsc.nat), jsc.nat, function(f, g, x) {
+  return stateEquals (jsc.nat) (
+    Z.chain (function() { return modify (compose (f) (g)); }, put (x)),
+    Z.chain (
+      function() { return modify (f); },
+      Z.chain (function() { return modify (g); }, put (x))
+    )
+  );
+});
+
+test ('.get is a state', function() {
+  eq (get instanceof State, true);
+});
+test ('.get sets the internal value to its state', function() {
+  eq (evalState (42) (get), 42);
+  eq (
+    evalState () (
+      Z.chain (function() { return get; }, put (42))
+    ),
+    42
+  );
+});
+
+test ('.run returns internal state an value', function() {
+  eq (run (42) (get), {state: 42, value: 42});
+});
+
+test ('.fantasy-land/chainRec should be stack-safe', function() {
+  eq (evalState () (
+    Z.chainRec (State, function(next, done, v) {
+      return Z.of (State, v < 10000 ? next (v + 1) : done (v));
+    }, 1)
+  ), 10000);
 });

--- a/test/statet.test.js
+++ b/test/statet.test.js
@@ -1,5 +1,7 @@
 import Z from 'sanctuary-type-classes';
 import Maybe from 'sanctuary-maybe';
+import jsc from 'jsverify';
+import test from 'oletus';
 
 import {
   deepStrictEqual as eq,
@@ -7,24 +9,18 @@ import {
 } from 'assert';
 
 import {
-  constant as _k,
-  fun,
-  nat
-} from 'jsverify';
-
-import {
   primitive,
   identity,
   stateEquals,
   property as _prop,
   assertEquals
-} from './utils';
+} from './utils.js';
 
 import {
   StateT,
   run,
   compose
-} from '..';
+} from '../index.js';
 
 var S = StateT (Maybe);
 var property = _prop (test);
@@ -37,128 +33,123 @@ function hoistFun(fn) {
   };
 }
 
-suite ('StateT (m)', function() {
-  test ('metadata', function() {
-    eq (typeof S, 'function');
-    eq (S.length, 1);
-  });
-  suite ('.put', function() {
-    test ('returns a StateT (m)', function() {
-      eq (S.put (42) instanceof S, true);
-      eq (S.put.length, 1);
-    });
-    test ('internal state is set to the given value', function() {
-      assertEquals (S.execState (0) (S.put (42)), Z.of (Maybe, 42));
-      assertEquals (
-        S.execState () (Z.chain (function() { return S.put (42); }, S.put (21))),
-        Z.of (Maybe, 42)
-      );
-    });
-  });
-  suite ('.modify', function() {
-    test ('returns a StateT (m)', function() {
-      eq (S.modify (Function.prototype) instanceof S, true);
-      eq (S.modify.length, 1);
-    });
-    test ('internal value is set to null', function() {
-      assertEquals (S.evalState () (S.modify (Function.prototype)), Z.of (Maybe, null));
-      assertEquals (
-        S.evalState () (Z.chain (
-          function() { return S.modify (Function.prototype); },
-          Z.of (S, 42)
-        )),
-        Z.of (Maybe, null)
-      );
-    });
-    property ('S.put (a).chain (_ => S.modify (identity)) === S.put (a)', primitive, function(x) {
-        return stateEquals (primitive) (
-          Z.chain (function() { return S.modify (identity); }, S.put (x)),
-          S.put (x)
-        );
-    });
-    property ('S.put (a).chain (_ => S.modify (compose (f) (g))) === S.put (a).chain (_ => S.modify (f)).chain (_ => S.modify (g))'
-    , _k (Math.sqrt), fun (nat), nat, function(f, g, x) {
-      return stateEquals (nat) (
-        Z.chain (function() { return S.modify (compose (f) (g)); }, S.put (x)),
-        Z.chain (
-          function() { return S.modify (f); },
-          Z.chain (function() { return S.modify (g); }, S.put (x))
-        )
-      );
-    });
-  });
-  suite ('.get', function() {
-    test ('is a StateT (m)', function() {
-      eq (S.get instanceof S, true);
-    });
-    test ('sets the internal value to its state', function() {
-      eq (S.evalState (42) (S.get), Z.of (Maybe, 42));
-      eq (
-        S.evalState () (
-          Z.chain (function() { return S.get; }, S.put (42))
-        ),
-        Z.of (Maybe, 42)
-      );
-    });
-  });
-  suite ('.run', function() {
-    test ('returns the internal state an value wrapped in a Monad', function() {
-      eq (run (42) (S.get), Z.of (Maybe, {state: 42, value: 42}));
-    });
-  });
-  suite ('.lift', function() {
-    test ('returns a StateT (m)', function() {
-      eq (S.lift (Z.of (Maybe, 1)) instanceof S, true);
-    });
-    property ('S.lift (M.of (n)) === S.of (n)', primitive, function(x) {
-      return stateEquals (primitive) (
-        S.lift (Z.of (Maybe, x)),
-        Z.of (S, x)
-      );
-    });
-  });
+test ('metadata', function() {
+  eq (typeof S, 'function');
+  eq (S.length, 1);
+});
 
-  suite ('.hoist', function() {
-    test ('returns a StateT (m)', function() {
-      eq (
-        S.hoist (Z.of (S, 1)) (Z.of (Maybe, Function.prototype)) instanceof S,
-        true
-      );
-    });
-    property ('S.hoist (Z.of (S, a)) (identity)) === Z.of (S, a)', primitive, function(x) {
-        return stateEquals (primitive) (
-          S.hoist (Z.of (S, x)) (identity),
-          Z.of (S, x)
-        );
-    });
-    property (
-      'S.hoist (Z.of (S, a)) (compose (f) (g))) === S.hoist (S.hoist (Z.of (S, a)) (g)) (f)',
-      _k (hoistFun (Math.sqrt)),
-      _k (hoistFun (mul3)),
-      nat,
-      function(f, g, x) {
-        return stateEquals (nat) (
-          S.hoist (Z.of (S, x)) (compose (f) (g)),
-          S.hoist (S.hoist (Z.of (S, x)) (g)) (f)
-        );
-      }
+test ('.put returns a StateT (m)', function() {
+  eq (S.put (42) instanceof S, true);
+  eq (S.put.length, 1);
+});
+test ('.put sets the internal state to the given value', function() {
+  assertEquals (S.execState (0) (S.put (42)), Z.of (Maybe, 42));
+  assertEquals (
+    S.execState () (Z.chain (function() { return S.put (42); }, S.put (21))),
+    Z.of (Maybe, 42)
+  );
+});
+
+test ('.modify returns a StateT (m)', function() {
+  eq (S.modify (Function.prototype) instanceof S, true);
+  eq (S.modify.length, 1);
+});
+test ('.modify changes the internal value to null', function() {
+  assertEquals (S.evalState () (S.modify (Function.prototype)), Z.of (Maybe, null));
+  assertEquals (
+    S.evalState () (Z.chain (
+      function() { return S.modify (Function.prototype); },
+      Z.of (S, 42)
+    )),
+    Z.of (Maybe, null)
+  );
+});
+
+property ('S.put (a).chain (_ => S.modify (identity)) === S.put (a)', primitive, function(x) {
+    return stateEquals (primitive) (
+      Z.chain (function() { return S.modify (identity); }, S.put (x)),
+      S.put (x)
     );
-  });
-  suite ('.fantasy-land/chainRec', function() {
-      test ('throws if the given monad is not ChainRec', function() {
-        return throws (
-          function() { return Z.chainRec ([], Function.prototype, 0); },
-          /ChainRec\.methods\.chainRec\(\.\.\.\) is not a function/
-        );
-      });
-      test ('is stack-safe', function() {
-        var s = Z.chainRec (S, function(next, done, v) {
-          return Z.of (S, v < 10000 ? next (v + 1) : done (v));
-        }, 1);
-        assertEquals (
-          S.evalState () (s),
-          Z.of (Maybe, 10000)
-        );
-      });
-    });
+});
+
+property ('S.put (a).chain (_ => S.modify (compose (f) (g))) === S.put (a).chain (_ => S.modify (f)).chain (_ => S.modify (g))'
+, jsc.constant (Math.sqrt), jsc.fun (jsc.nat), jsc.nat, function(f, g, x) {
+  return stateEquals (jsc.nat) (
+    Z.chain (function() { return S.modify (compose (f) (g)); }, S.put (x)),
+    Z.chain (
+      function() { return S.modify (f); },
+      Z.chain (function() { return S.modify (g); }, S.put (x))
+    )
+  );
+});
+
+test ('.get is a StateT (m)', function() {
+  eq (S.get instanceof S, true);
+});
+test ('.get sets the internal value to its state', function() {
+  eq (S.evalState (42) (S.get), Z.of (Maybe, 42));
+  eq (
+    S.evalState () (
+      Z.chain (function() { return S.get; }, S.put (42))
+    ),
+    Z.of (Maybe, 42)
+  );
+});
+
+test ('.run returns the internal state an value wrapped in a Monad', function() {
+  eq (run (42) (S.get), Z.of (Maybe, {state: 42, value: 42}));
+});
+
+test ('.lift returns a StateT (m)', function() {
+  eq (S.lift (Z.of (Maybe, 1)) instanceof S, true);
+});
+
+property ('S.lift (M.of (n)) === S.of (n)', primitive, function(x) {
+  return stateEquals (primitive) (
+    S.lift (Z.of (Maybe, x)),
+    Z.of (S, x)
+  );
+});
+
+test ('.hoist returns a StateT (m)', function() {
+  eq (
+    S.hoist (Z.of (S, 1)) (Z.of (Maybe, Function.prototype)) instanceof S,
+    true
+  );
+});
+
+property ('S.hoist (Z.of (S, a)) (identity)) === Z.of (S, a)', primitive, function(x) {
+    return stateEquals (primitive) (
+      S.hoist (Z.of (S, x)) (identity),
+      Z.of (S, x)
+    );
+});
+
+property (
+  'S.hoist (Z.of (S, a)) (compose (f) (g))) === S.hoist (S.hoist (Z.of (S, a)) (g)) (f)',
+  jsc.constant (hoistFun (Math.sqrt)),
+  jsc.constant (hoistFun (mul3)),
+  jsc.nat,
+  function(f, g, x) {
+    return stateEquals (jsc.nat) (
+      S.hoist (Z.of (S, x)) (compose (f) (g)),
+      S.hoist (S.hoist (Z.of (S, x)) (g)) (f)
+    );
+  }
+);
+
+test ('.fantasy-land/chainRec throws if the given monad is not ChainRec', function() {
+  return throws (
+    function() { return Z.chainRec ([], Function.prototype, 0); },
+    /ChainRec\.methods\.chainRec\(\.\.\.\) is not a function/
+  );
+});
+test ('.fantasy-land/chainRec is stack-safe', function() {
+  var s = Z.chainRec (S, function(next, done, v) {
+    return Z.of (S, v < 10000 ? next (v + 1) : done (v));
+  }, 1);
+  assertEquals (
+    S.evalState () (s),
+    Z.of (Maybe, 10000)
+  );
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,18 +1,8 @@
 import Z from 'sanctuary-type-classes';
-
 import {deepStrictEqual} from 'assert';
+import jsc from 'jsverify';
 
-import {
-  assert,
-  forall,
-  number,
-  oneof,
-  falsy,
-  string,
-  bool
-} from 'jsverify';
-
-import {run} from '../';
+import {run} from '../index.js';
 
 function eq(expected) {
   return function(actual) {
@@ -38,12 +28,12 @@ export function property(t) {
   return function(property) {
     var args = Array.prototype.slice.call (arguments, 1);
     return t (property, function() {
-      assert (forall.apply (this, args));
+      jsc.assert (jsc.forall.apply (this, args));
     });
   };
 }
 
 export function identity(x) { return x; }
 
-export var truthy = oneof (number, string, bool);
-export var primitive = oneof (truthy, falsy);
+export var truthy = jsc.oneof (jsc.number, jsc.string, jsc.bool);
+export var primitive = jsc.oneof (truthy, jsc.falsy);


### PR DESCRIPTION
## Motivation

Close #12
Close #13 and contribute towards #14

## Changes

- Package type set to module so all the `.js` files are interpreted as ESM.
- Build output renamed to index.cjs. Cjs extension is used to make explicit the fact that is a CommonJS file.
- > Package entry point change from index to index.js: Node 12 no longer switches transparently between the most appropriate index file. Every package must provide an explicit path to its entry-point. -- @avaq
- > Rollup config file extension changed: Node 12 forbids require('*.mjs') calls. Since this is how, deep down, the file was being loaded by Rollup, we get an error in Node 12. -- @avaq

