### PR TITLE
Remove misleading documentation about usage with ESM and Commonjs

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,13 +9,6 @@
 //. ```console
 //. $ npm install --save monastic
 //. ```
-//.
-//. On Node 12 and up, you can use `import {State} from 'monastic'`.
-//. Older versions of Node require the use of
-//. [`esm`](https://github.com/standard-things/esm).
-//.
-//. Alternatively, a universal module can be obtained
-//. through `require('monastic/index.cjs')`.
 
 import Z from 'sanctuary-type-classes';
 


### PR DESCRIPTION
Due to a confusion I thought that #16 would change package distribution to ESM-first.

I might publish a new version just to update the README.