### PR TITLE
Add missing "./" to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,8 +14,8 @@
   "main": "index.cjs",
   "module": "index.js",
   "exports": {
-    "import": "index.js",
-    "require": "index.cjs"
+    "import": "./index.js",
+    "require": "./index.cjs"
   },
   "scripts": {
     "build": "rollup -c rollup.config.js",


### PR DESCRIPTION
I didn't realize :man_facepalming: 

```
Error [ERR_INVALID_PACKAGE_TARGET]: Invalid "exports" main target index.js defined in the package config
/home/diego/dev/fluture/momi/node_modules/monastic/package.json imported from
/home/diego/dev/fluture/momi/test/index.js; targets must start with "./"
```